### PR TITLE
Implement backend Dockerfile

### DIFF
--- a/Nexus/README.md
+++ b/Nexus/README.md
@@ -1,0 +1,28 @@
+# Nexus
+
+This repository contains a small example of a multi service backend.
+Two separate services live under `backend/`:
+
+- `auth` – a Node.js authentication service
+- `main_service` – a Django application
+
+## Using docker-compose
+
+Inside `backend/` there is a `docker-compose.yml` file that starts both
+services together with their dependencies (MongoDB, MySQL, Prometheus and
+Grafana). Run the following commands from the `backend` directory:
+
+```bash
+docker-compose up --build
+```
+
+## Single container image
+
+If you prefer to run both services inside one container for development,
+use the Dockerfile located at `backend/Dockerfile`.
+Build and run the image from the repository root with:
+
+```bash
+docker build -t nexus-backend ./backend
+docker run -p 5000:5000 -p 8000:8000 nexus-backend
+```

--- a/Nexus/backend/Dockerfile
+++ b/Nexus/backend/Dockerfile
@@ -1,0 +1,38 @@
+# Multi-service Dockerfile for running both the authentication
+# and main Django services in a single container.
+
+FROM python:3.9
+
+# Install Node.js for the auth service
+RUN apt-get update \
+    && apt-get install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install -y nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /usr/src/app
+
+# Copy service code
+COPY auth ./auth
+COPY main_service ./main_service
+
+# Install dependencies for the auth service
+WORKDIR /usr/src/app/auth
+RUN npm install
+
+# Install dependencies for the Django service
+WORKDIR /usr/src/app/main_service
+RUN pip install -r requirements.txt
+
+# Copy start script
+WORKDIR /usr/src/app
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+# Expose service ports
+EXPOSE 5000 8000
+
+# Run both services
+CMD ["./start.sh"]

--- a/Nexus/backend/start.sh
+++ b/Nexus/backend/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Start both the Django main_service and the Node auth service
+
+# Start Django service in background
+cd /usr/src/app/main_service
+python manage.py runserver 0.0.0.0:8000 &
+
+# Start Node authentication service
+cd /usr/src/app/auth
+node app.js


### PR DESCRIPTION
## Summary
- add Dockerfile that starts Django and Node services in one container
- add a simple start script
- document how to build and run the container

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840c94b75d8832caab5ba691816baf9