### PR TITLE
Add backend unit tests

### DIFF
--- a/Nexus/backend/auth/package.json
+++ b/Nexus/backend/auth/package.json
@@ -5,7 +5,8 @@
     "main": "app.js",
     "scripts": {
         "start": "node app.js",
-        "dev": "nodemon app.js"
+        "dev": "nodemon app.js",
+        "test": "jest"
     },
     "dependencies": {
         "bcryptjs": "^2.4.3",
@@ -17,7 +18,9 @@
         "mongoose": "^8.5.1"
     },
     "devDependencies": {
-        "nodemon": "^2.0.7"
+        "nodemon": "^2.0.7",
+        "jest": "^29.0.0",
+        "supertest": "^6.0.0"
     },
     "author": "Omercan&Senanur",
     "license": "ISC"

--- a/Nexus/backend/auth/src/test/auth.test.js
+++ b/Nexus/backend/auth/src/test/auth.test.js
@@ -1,5 +1,69 @@
-// You can use a testing library like Jest for writing your tests
+const authController = require('../controllers/authController');
+const productController = require('../controllers/productController');
+const User = require('../models/userModel');
+const Product = require('../models/productModel');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
 
-test('sample test', () => {
-    expect(true).toBe(true);
+jest.mock('../models/userModel');
+jest.mock('../models/productModel');
+jest.mock('bcryptjs');
+jest.mock('jsonwebtoken');
+
+describe('Auth Controller', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = { body: {} };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('register returns 400 if user already exists', async () => {
+    req.body = { email: 'test@example.com', password: 'secret' };
+    User.findOne.mockResolvedValue(true);
+
+    await authController.register(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ msg: 'User already exists' });
+  });
+
+  test('login returns 400 when user not found', async () => {
+    req.body = { email: 'test@example.com', password: 'secret' };
+    User.findOne.mockResolvedValue(null);
+
+    await authController.login(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ msg: 'Invalid credentials' });
+  });
+
+  test('login returns token with valid credentials', async () => {
+    req.body = { email: 'test@example.com', password: 'secret' };
+    const user = { id: '1', password: 'hashed' };
+    User.findOne.mockResolvedValue(user);
+    bcrypt.compare.mockResolvedValue(true);
+    jwt.sign.mockImplementation((payload, secret, options, cb) => cb(null, 'tok')); 
+
+    await authController.login(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ token: 'tok' });
+  });
+});
+
+describe('Product Controller', () => {
+  test('getProducts returns product list', async () => {
+    const req = {};
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    Product.find.mockResolvedValue([{ name: 'p1' }]);
+
+    await productController.getProducts(req, res);
+
+    expect(res.json).toHaveBeenCalledWith([{ name: 'p1' }]);
+  });
 });

--- a/Nexus/backend/main_service/Nexus/tests.py
+++ b/Nexus/backend/main_service/Nexus/tests.py
@@ -1,3 +1,53 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from .models import Product, Order, Payment
 
-# Create your tests here.
+
+class ProductAPITestCase(APITestCase):
+    def test_create_and_list_products(self):
+        url = reverse('product-list')
+        data = {
+            'name': 'Phone',
+            'description': 'Smart phone',
+            'price': '99.99',
+            'stock': 10,
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Product.objects.count(), 1)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+
+class OrderPaymentAPITestCase(APITestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            name='Tablet',
+            description='Android tablet',
+            price='150.00',
+            stock=5,
+        )
+
+    def test_order_and_payment_flow(self):
+        order_url = reverse('order-list')
+        order_data = {
+            'product': self.product.id,
+            'quantity': 2,
+            'total_price': '300.00',
+        }
+        order_resp = self.client.post(order_url, order_data, format='json')
+        self.assertEqual(order_resp.status_code, status.HTTP_201_CREATED)
+        order_id = order_resp.data['id']
+
+        payment_url = reverse('payment-list')
+        payment_data = {
+            'order': order_id,
+            'amount': '300.00',
+        }
+        payment_resp = self.client.post(payment_url, payment_data, format='json')
+        self.assertEqual(payment_resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Payment.objects.count(), 1)
+


### PR DESCRIPTION
## Summary
- implement Jest unit tests for controllers in the auth service
- update auth package.json to run Jest
- create DRF API tests for product, order, and payment endpoints

## Testing
- `npm test` *(fails: jest not found)*
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840c94a6b50832cbe39c7468fc0152a