### PR TITLE
Add sample monitoring configs

### DIFF
--- a/Nexus/infra/docker/monitoring/grafana/dashboards/main.json
+++ b/Nexus/infra/docker/monitoring/grafana/dashboards/main.json
@@ -1,0 +1,27 @@
+{
+  "uid": "nexus-main",
+  "title": "Sample Dashboard",
+  "schemaVersion": 34,
+  "version": 1,
+  "timezone": "browser",
+  "refresh": "5s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Up",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "up",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/Nexus/infra/docker/monitoring/prometheus/prometheus.yml
+++ b/Nexus/infra/docker/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']


### PR DESCRIPTION
## Summary
- provide a sample Grafana dashboard JSON
- add a Prometheus scrape configuration example

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9491170832c9242704274c4c3e3