### PR TITLE
Add infrastructure Dockerfiles and package configs

### DIFF
--- a/Nexus/README.md
+++ b/Nexus/README.md
@@ -1,0 +1,18 @@
+# Nexus
+
+Minimal instructions for building the backend containers.
+
+```bash
+# Build the authentication service
+docker build -f infra/docker/auth/Dockerfile -t nexus-auth .
+
+# Build the main service
+docker build -f infra/docker/main_service/Dockerfile -t nexus-main .
+```
+
+Run the stack with Docker Compose:
+
+```bash
+cd infra/docker
+docker compose up
+```

--- a/Nexus/frontend/desktop/package.json
+++ b/Nexus/frontend/desktop/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nexus-desktop",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder"
+  },
+  "dependencies": {
+    "electron": "^28.1.0"
+  },
+  "devDependencies": {
+    "electron-builder": "^24.6.0"
+  }
+}
+

--- a/Nexus/frontend/mobile/package.json
+++ b/Nexus/frontend/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nexus-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0"
+  }
+}
+

--- a/Nexus/frontend/web/package.json
+++ b/Nexus/frontend/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nexus-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  }
+}
+

--- a/Nexus/infra/docker/auth/Dockerfile
+++ b/Nexus/infra/docker/auth/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:16
+
+# Set working directory inside the container
+WORKDIR /usr/src/app
+
+# Copy package files from the backend service and install dependencies
+COPY ../../backend/auth/package*.json ./
+RUN npm install
+
+# Copy the rest of the auth service code
+COPY ../../backend/auth .
+
+# Expose service port
+EXPOSE 5000
+
+# Default command
+CMD ["node", "app.js"]

--- a/Nexus/infra/docker/main_service/Dockerfile
+++ b/Nexus/infra/docker/main_service/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.9
+
+ENV PYTHONUNBUFFERED=1
+
+# Working directory for the application
+WORKDIR /usr/src/app
+
+# Install Python dependencies
+COPY ../../backend/main_service/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY ../../backend/main_service .
+
+# Expose application port
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- implement Dockerfiles for auth and main service under `infra/docker`
- fill in package.json files for web, mobile and desktop frontends
- document how to build and run the containers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c9419d34832ca1f0ecc188ac1764